### PR TITLE
Add text for RFC 5928 and RFC 7065

### DIFF
--- a/draft-chenxin-behave-turn-websocket.xml
+++ b/draft-chenxin-behave-turn-websocket.xml
@@ -335,7 +335,55 @@ is the following (the original BNF for this parameter can be found in
 		    </figure>
 		</t>
 
+		<t>The &lt;transport&gt; component is passed without modification to the <xref target="RFC5928" /> algorithm, which is used according to section <xref target="section.operation.resolution" />.</t>
+
+		<t>
+			Note that using the <xref target="RFC5928" /> resolution mechanism does not implies that additional round trips to the DNS server will be needed.
+			E.g. the TURN client will start immediately if the URL contains an IP address.
+		</t>
 	    </section>
+
+		<section anchor="section.operation.resolution" title="Resolution mechanism for TURN over Websockets">
+			<t>
+				Two additional application service tags are defined by this document, "turn.ws" and "turn.ws".
+				The resolution mechanism described in <xref target="RFC5928" /> is modified as follow:
+			</t>
+
+			<t>
+				<list>
+					<t>The transport name list is extended with the name "ws".</t>
+					<t>The ordered list of supported TURN transport is extended with the WS and WSS transports.</t>
+					<t>The resolution algorithm ckeck rules list is extended with the following steps:
+						<list style="symbols">
+							<t>If &lt;secure&gt; is false and &lt;transport&gt; is defined as "ws" but the list of TURN transports supported by the application does not contain WS, then the resolution MUST stop with an error</t>
+							<t>If &lt;secure&gt; is true and &lt;transport&gt; is defined as "ws" but the list of TURN transports supported by the application does not contain WSS, then the resolution MUST stop with an error</t>
+						</list>
+					</t>
+					<t>The 5th rule of the resolution algorithm check rules list is modified to read like this:
+						<list style="symbols">
+							<t>If &lt;secure&gt; is true and &lt;transport&gt; is not defined but the list of TURN transports supported by the application does not contain TLS or WSS, then the resolution MUST stop with an error</t>
+						</list>
+					</t>
+					<t>The filtering step is modified so the WS TURN transport is also removed if &lt;secure&gt; is true.</t>
+					<t>Table 1 is modified to add the following lines:</t>
+				</list>
+			</t>
+			<texttable>
+				<ttcol>&lt;secure&gt;</ttcol>
+				<ttcol>&lt;transport&gt;</ttcol>
+				<ttcol>TURN Transport</ttcol>
+				<c>false</c> <c/> <c>"ws"</c> <c>WS</c>
+				<c>true</c> <c/> <c>"ws"</c> <c>WSS</c>
+			</texttable>
+			<t>In step 1 the default port for the WS transport is 80, the default port for WSS is 443. </t>
+			<t>In step 4 The following is added to the list of convertions between the filtered list of supported TURN transports and application protocol tags:
+				<list>
+					<t>"turn.ws" is used if the TURN transport is WS,</t>
+					<t>"turn.wss" is used if the TURN transport is WSS.</t>
+				</list>
+			</t>
+		</section>
+
 	    <section title="Impact on ICE candidates and SDP signalling" anchor="ICE_SDP_impact">
 		   <t>
 This specification does not have any impact on ICE. In fact, all the related candidates would be allocated
@@ -344,6 +392,43 @@ at the TURN sever, and as such no modifications are needed in the SDP signaling 
 	    </section>
 
 	</section>
+
+		<section anchor="section.ref-impl" title="Implementation Status">
+			<t>Note to RFC Editor: Please remove this section and the reference to <xref target="RFC6982" /> before publication.</t>
+
+			<t>
+				This section records the status of known implementations of the protocol defined by this specification at the time of posting of this Internet-Draft, and is based on a proposal described in <xref target="RFC6982" />.
+				The description of implementations in this section is intended to assist the IETF in its decision processes in progressing drafts to RFCs.
+				Please note that the listing of any individual implementation here does not imply endorsement by the IETF.
+				Furthermore, no effort has been spent to verify the information presented here that was supplied by IETF contributors.
+				This is not intended as, and must not be construed to be, a catalog of available implementations or their features.
+				Readers are advised to note that other implementations may exist.
+			</t>
+
+			<t>
+				According to <xref target="RFC6982" />, "this will allow reviewers and working groups to assign due consideration to documents that have the benefit of running code, which may serve as evidence of valuable experimentation and feedback that have made the implemented protocols more mature.
+				It is up to the individual working groups to use this information as they see fit".
+			</t>
+
+			<section anchor="section.impl-status.turnuri" title="turnuri">
+				<t>
+					<list style="hanging">
+						<t hangText="Organization: ">Impedance Mismatch</t>
+						<t hangText="Name: ">
+							turnuri 0.4.0
+							http://debian.implementers.org/stable/source/turnuri.tar.gz
+						</t>
+						<t hangText="Description: ">A reference implementation of the URI and resolution mechanism defined in this document, of draft-petithuguenin-behave-turn-uris and of <xref target="RFC5928">RFC 5928</xref>.</t>
+						<t hangText="Level of maturity: ">Beta.</t>
+						<t hangText="Coverage: ">Fully implements the URIs and resolution mechanism defined in this specification, in draft-petithuguenin-behave-turn-uris and in RFC 5928.</t>
+						<t hangText="Licensing: ">AGPL3</t>
+						<t hangText="Implementation experience: "></t>
+						<t hangText="Contact: ">Marc Petit-Huguenin &lt;marc@petit-huguenin.org&gt;.</t>
+					</list>
+				</t>
+			</section>
+		</section>
+
 	<section title="IANA Considerations">
 	    <t>
 RFC Editor Note: Please set the RFC number assigned for this
@@ -362,8 +447,40 @@ sub-protocol under the "WebSocket Subprotocol Name" Registry with the following 
 		</t>
 	    </section>
 
+		<section title="Application Protocol Tag Registrations">
+			<t>This specification contains the registration information for two S-NAPTR application protocol tags (in accordance with <xref target="RFC3958" />).</t>
+
+			<section title="turn.ws Application Protocol Tag Registration">
+				<t>
+					<list style="hanging">
+						<t hangText="Application Protocol Tag: ">turn.ws</t>
+						<t hangText="Intented Usage: ">See <xref target="section.operation.resolution" /></t>
+						<t hangText="Interoperability considerations: ">N/A</t>
+						<t hangText="Security considerations: ">See <xref target="section.security" /></t>
+						<t hangText="Relevant publications: ">This document</t>
+						<t hangText="Contact information: ">Marc Petit-Huguenin</t>
+						<t hangText="Author/Change controller: ">The IESG</t>
+					</list>
+				</t>
+			</section>
+
+			<section title="turn.wss Application Protocol Tag Registration">
+				<t>
+					<list style="hanging">
+						<t hangText="Application Protocol Tag: ">turn.wss</t>
+						<t hangText="Intented Usage: ">See <xref target="section.operation.resolution" /></t>
+						<t hangText="Interoperability considerations: ">N/A</t>
+						<t hangText="Security considerations: ">See <xref target="section.security" /></t>
+						<t hangText="Relevant publications: ">This document</t>
+						<t hangText="Contact information: ">Marc Petit-Huguenin</t>
+						<t hangText="Author/Change controller: ">The IESG</t>
+					</list>
+				</t>
+			</section>
+		</section>
+
 	</section>
-	<section title="Security Considerations">
+	<section anchor="section.security" title="Security Considerations">
 	    <t>
 TBD.
 	    </t>
@@ -373,6 +490,19 @@ TBD.
 	
 		<t>Note to RFC Editor:  Please remove this whole section.</t>
 
+		<t>
+The following are the major changes between the
+01 and the 02 versions of the draft:
+		</t>
+		<t>
+			<list style="symbols">
+				<t>Moved draft-petithuguenin-behave-turn-uris to normative references section.</t>
+				<t>Added normative reference to RFC 5928.</t>
+				<t>Added text for support of RFC 5928 resolution mechanism.</t>
+				<t>Added RFC 6982 template.</t>
+				<t>Added registrations for turn.ws and turn.wss application tags.</t>
+			</list>
+		</t>
 		<t>
 The following are the major changes between the
 00 and the 01 versions of the draft:
@@ -396,8 +526,11 @@ Paul Kyzivat helped with the formatting of this draft.
 
     <back>
 	<references title="Normative References">
+      <?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.3958.xml"?>
       <?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.5766.xml"?>
+      <?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.5928.xml"?>
       <?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.6062.xml"?>
+      <?rfc include="http://xml.resource.org/public/rfc/bibxml3/reference.I-D.petithuguenin-behave-turn-uris"?>
 	</references>
 	<references title="Informative References">
       <?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml"?>
@@ -407,10 +540,67 @@ Paul Kyzivat helped with the formatting of this draft.
       <?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.6454.xml"?>
       <?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.5246.xml"?>
       <?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.2616.xml"?>
-      <?rfc include="http://xml.resource.org/public/rfc/bibxml3/reference.I-D.draft-petithuguenin-behave-turn-uris-06.xml"?>
+      <?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.6982.xml"?>
       <?rfc include="http://xml.resource.org/public/rfc/bibxml3/reference.I-D.draft-ietf-rtcweb-use-cases-and-requirements-11.xml"?>
 	</references>
 
 
+	<section title="Examples">
+		<t>
+			<xref target="example.1" /> show how the &lt;secure&gt;, &lt;port&gt; and &lt;transport&gt; components are populated from various URIs.
+			For all these examples, the &lt;host&gt; component is populated with "example.org".
+		</t>
+
+		<texttable anchor="example.1">
+			<ttcol>URI</ttcol>
+			<ttcol>&lt;secure&gt;</ttcol>
+			<ttcol>&lt;port&gt;</ttcol>
+			<ttcol>&lt;transport&gt;</ttcol>
+			<c>turn:example.org?transport=ws</c> <c>false</c> <c/> <c>WS</c>
+			<c>turns:example.org?transport=ws</c> <c>true</c> <c/> <c>WS</c>
+		</texttable>
+
+		<t>With the DNS RRs in <xref target="example.2" /> and an ordered TURN transport list of { TLS, WSS, TCP, WS, UDP }, the resolution mechanism will convert the TURN URI "turn:example.net" to the ordered list of IP address, port, and protocol tuples in <xref target="table.2" />.</t>
+
+		<figure anchor="example.2">
+			<artwork><![CDATA[example.net.
+IN NAPTR 100 10 "" RELAY:turn.udp "" datagram.example.net.
+IN NAPTR 200 10 "" RELAY:turn.tcp:turn.tls "" stream.example.net.
+IN NAPTR 300 10 "" RELAY:turn.ws:turn.wss "" websocket.example.net.
+
+datagram.example.net.
+IN NAPTR 100 10 S RELAY:turn.udp "" _turn._udp.example.net.
+
+stream.example.net.
+IN NAPTR 100 10 S RELAY:turn.tcp "" _turn._tcp.example.net.
+IN NAPTR 200 10 A RELAY:turn.tls "" a.example.net.
+
+websocket.example.net.
+IN NAPTR 100 10 S RELAY:turn.ws "" _turn._ws.example.net.
+IN NAPTR 200 10 A RELAY:turn.wss "" a.example.net.
+
+_turn._udp.example.net.
+IN SRV   0 0 3478 a.example.net.
+
+_turn._tcp.example.net.
+IN SRV   0 0 5000 a.example.net.
+
+_turn._ws.example.net.
+IN SRV   0 0 8080 a.example.net.
+
+a.example.net.
+IN A     192.0.2.1]]>
+			</artwork>
+		</figure>
+
+		<texttable anchor="table.2">
+			<ttcol>Order</ttcol><ttcol>Protocol</ttcol><ttcol>IP address</ttcol><ttcol>Port</ttcol>
+			<c>1</c><c>UDP</c><c>192.0.2.1</c><c>3478</c>
+			<c>2</c><c>TLS</c><c>192.0.2.1</c><c>5349</c>
+			<c>3</c><c>TCP</c><c>192.0.2.1</c><c>5000</c>
+			<c>4</c><c>WSS</c><c>192.0.2.1</c><c>443</c>
+			<c>5</c><c>WS</c><c>192.0.2.1</c><c>8080</c>
+		</texttable>
+	</section>
     </back>
 </rfc>


### PR DESCRIPTION
- Added text to explain RFC 5928 resolution when used with Websockets.
- Added implementation status section.
- Added Application Protocol Tag Registration for turn.ws and turn.wss.
- Added example.
